### PR TITLE
Preserve practice checkpoints when starting recording

### DIFF
--- a/src/ui/record_layer.cpp
+++ b/src/ui/record_layer.cpp
@@ -503,9 +503,14 @@ void RecordLayer::toggleRecording(CCObject*) {
     if (g.state == state::recording) {
         g.currentAction = 0;
         g.currentFrameFix = 0;
-        g.restart = true;
 
         PlayLayer* pl = PlayLayer::get();
+        // Restarting from the beginning clears Geometry Dash's practice
+        // checkpoint stack. When recording is started mid-practice, keep the
+        // existing checkpoints and continue from the current practice state
+        // instead of deleting every checkpoint the player has placed.
+        g.restart = !(pl && pl->m_isPracticeMode && !g.checkpoints.empty());
+
         if (pl) {
             if (!pl->m_isPaused)
                 pl->pauseGame(false);


### PR DESCRIPTION
### Motivation
- Fix a bug where starting macro recording would always force a level restart and clear all practice checkpoints, causing players to lose their placed checkpoints when recording mid-practice.

### Description
- Change `RecordLayer::toggleRecording` to set `g.restart` only when not in practice mode with existing checkpoints, preserving the practice checkpoint stack; the change is in `src/ui/record_layer.cpp` and includes an explanatory comment. 

### Testing
- Ran `git diff --check`, which returned clean results. 
- Attempted `cmake -S . -B /tmp/geobot-build`, which could not complete because `GEODE_SDK` is not configured in this environment. 
- Repository actions: changed files (yes), ran verification (yes), created a commit (yes), pushed to `origin` (no — remote not configured).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restart behavior in practice mode: When entering recording mode, the game now intelligently manages restarts. If you're in practice mode with existing checkpoints, your progress is preserved instead of restarting from the beginning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->