### PR TITLE
Remove references to removed PlayerObject::m_unk9e8 binding

### DIFF
--- a/src/macro.hpp
+++ b/src/macro.hpp
@@ -239,7 +239,6 @@ struct PlayerData {
     double m_maybeReverseAcceleration;
     float m_xVelocityRelated2;
     bool m_isDashing;
-    int m_unk9e8;
     int m_groundObjectMaterial;
     float m_vehicleSize;
     float m_playerSpeed;

--- a/src/practice_fixes/player.cpp
+++ b/src/practice_fixes/player.cpp
@@ -168,7 +168,6 @@ PlayerData PlayerPracticeFixes::saveData(PlayerObject* player) {
     data.m_maybeReverseAcceleration = player->m_maybeReverseAcceleration;
     data.m_xVelocityRelated2 = player->m_xVelocityRelated2;
     data.m_isDashing = player->m_isDashing;
-    data.m_unk9e8 = player->m_unk9e8;
     data.m_groundObjectMaterial = player->m_groundObjectMaterial;
     data.m_vehicleSize = player->m_vehicleSize;
     data.m_playerSpeed = player->m_playerSpeed;
@@ -424,7 +423,6 @@ void PlayerPracticeFixes::applyData(PlayerObject* player, PlayerData data, bool 
     player->m_maybeReverseAcceleration = data.m_maybeReverseAcceleration;
     player->m_xVelocityRelated2 = data.m_xVelocityRelated2;
     if (!isFakePlayer) player->m_isDashing = data.m_isDashing;
-    player->m_unk9e8 = data.m_unk9e8;
     player->m_groundObjectMaterial = data.m_groundObjectMaterial;
     player->m_vehicleSize = data.m_vehicleSize;
     player->m_playerSpeed = data.m_playerSpeed;


### PR DESCRIPTION
### Motivation
- Remove references to a binding field that no longer exists in `PlayerObject` to fix build errors referencing `m_unk9e8` during practice-data snapshot/restore.

### Description
- Deleted the read/write of `m_unk9e8` in `src/practice_fixes/player.cpp` and removed the corresponding `PlayerData::m_unk9e8` field from `src/macro.hpp` so player checkpoint save/restore no longer references the missing binding.

### Testing
- Ran `git diff --check` (passed); attempted `cmake --build build --target geobot2 -j2` could not run because `GEODE_SDK` is unset and no `build` directory exists, and an attempted bindings fetch for further verification failed due to network/permission (HTTP 403); a commit was created (`ebf4864`) but `git push origin HEAD` failed because this checkout has no `origin` remote configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c340a3814832888da94ca4266212d)