### PR TITLE
Release 1.1: remove alpha feature-flag labels and fix Pathfinder access

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 1.1.0
+* remove alpha/development labels from feature flags
+* fix pathfinder feature flag access
+
+
 # 1.0.0
 * full realce i cant spell. nexttime:)
 

--- a/mod.json
+++ b/mod.json
@@ -4,7 +4,7 @@
         "win": "2.2081",
         "android": "2.2081"
     },
-    "version": "1.0.0",
+    "version": "1.1.0",
     "id": "benno111.geobot",
     "name": "geobot",
     "developer": "Benno111",
@@ -25,13 +25,13 @@
         }
     },
     "settings": {
-        "feature_flag_frameperfect_detection (Alpha)": {
+        "feature_flag_frameperfect_detection": {
             "name": "Enable Frameperfect Detection",
             "description": "Turns the frameperfect detection system on or off.",
             "type": "bool",
             "default": false
         },
-        "feature_flag_pathfinder (Alpha)": {
+        "feature_flag_pathfinder": {
             "name": "Enable Pathfinder",
             "description": "Turns the pathfinder system on or off.",
             "type": "bool",

--- a/src/gdr/gdr.hpp
+++ b/src/gdr/gdr.hpp
@@ -14,7 +14,7 @@ cocos2d::CCPoint dataFromString(std::string dataString);
 
 std::vector<std::string> splitByChar(std::string str, char splitChar);
 
-const std::string geobotVersion = "alpha 2";
+const std::string geobotVersion = "1.1";
 constexpr bool geobotDisableBuildExpiryLock = true;
 
 namespace gdr {


### PR DESCRIPTION
### Motivation
- Remove misleading "alpha/development" suffixes from feature-flag setting IDs so runtime code can read and toggle the features correctly. 
- Bump the mod version and internal displayed version to 1.1 to reflect the release and associated fixes. 
- Fix the bug where the Pathfinder controls were inaccessible after enabling the feature flag by aligning the setting IDs with the runtime checks.

### Description
- Updated `mod.json` to set `version` to `1.1.0` and removed the ` (Alpha)` suffixes from the `feature_flag_frameperfect_detection` and `feature_flag_pathfinder` setting IDs. 
- Updated the internal/displayed version string in `src/gdr/gdr.hpp` from `"alpha 2"` to `"1.1"`. 
- Added a `1.1.0` entry to `changelog.md` describing the change. 
- These changes ensure `Global::isPathfinderFeatureEnabled()` and other runtime checks can find the feature flags and allow the Pathfinder UI/toggles to function after enabling the feature. 

### Testing
- Validated `mod.json` syntax with `python3 -m json.tool mod.json` which succeeded. 
- Ran `git diff --check` to ensure no whitespace or diff issues, which succeeded. 
- Attempted `cmake -S . -B build -Dgeobot_ENABLE_TEST_BUILDS=OFF` but configure failed because the `GEODE_SDK` environment variable is not set in this environment. 
- Created a commit (`Release 1.1 pathfinder fixes`) containing the updates, and attempted to push but the push failed because `origin` is not configured in this checkout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30176480ac83289b531b4c0dec39af)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed feature-flag access for the pathfinder feature.

* **Chores**
  * Released version 1.1.0.
  * Promoted feature flags from alpha status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->