### PR TITLE
Add loading-screen popup positioning, bump version to 1.1.0, and fix Pathfinder settings access

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 1.1.0
+* remove alpha/development labels from feature flags
+* fix pathfinder feature flag access
+
+
 # 1.0.0
 * full realce i cant spell. nexttime:)
 

--- a/mod.json
+++ b/mod.json
@@ -4,7 +4,7 @@
         "win": "2.2081",
         "android": "2.2081"
     },
-    "version": "1.0.0",
+    "version": "1.1.0",
     "id": "benno111.geobot",
     "name": "geobot",
     "developer": "Benno111",
@@ -25,13 +25,13 @@
         }
     },
     "settings": {
-        "feature_flag_frameperfect_detection (Alpha)": {
+        "feature_flag_frameperfect_detection": {
             "name": "Enable Frameperfect Detection",
             "description": "Turns the frameperfect detection system on or off.",
             "type": "bool",
             "default": false
         },
-        "feature_flag_pathfinder (Alpha)": {
+        "feature_flag_pathfinder": {
             "name": "Enable Pathfinder",
             "description": "Turns the pathfinder system on or off.",
             "type": "bool",

--- a/src/gdr/gdr.hpp
+++ b/src/gdr/gdr.hpp
@@ -14,7 +14,7 @@ cocos2d::CCPoint dataFromString(std::string dataString);
 
 std::vector<std::string> splitByChar(std::string str, char splitChar);
 
-const std::string geobotVersion = "alpha 2";
+const std::string geobotVersion = "1.1";
 constexpr bool geobotDisableBuildExpiryLock = true;
 
 namespace gdr {

--- a/src/includes.hpp
+++ b/src/includes.hpp
@@ -26,6 +26,16 @@ class Popup : public geode::Popup {
 protected:
     virtual bool setup(SetupArgs... args) = 0;
 
+    void adjustForLoadingScreen(bool includeTitle = true) {
+        cocos2d::CCPoint offset = (cocos2d::CCDirector::sharedDirector()->getWinSize() - m_mainLayer->getContentSize()) / 2;
+        m_mainLayer->setPosition(m_mainLayer->getPosition() - offset);
+        m_closeBtn->setPosition(m_closeBtn->getPosition() + offset);
+        m_bgSprite->setPosition(m_bgSprite->getPosition() + offset);
+
+        if (includeTitle && m_title)
+            m_title->setPosition(m_title->getPosition() + offset);
+    }
+
 public:
     bool initAnchored(
         float width,

--- a/src/ui/autoclicker_settings_layer.hpp
+++ b/src/ui/autoclicker_settings_layer.hpp
@@ -47,6 +47,7 @@ private:
 	
     bool setup() override {
         setTitle("Autoclicker");
+        adjustForLoadingScreen();
 		m_title->setScale(0.625f);
 		m_title->setPositionY(224);
 

--- a/src/ui/autosave_settings_layer.hpp
+++ b/src/ui/autosave_settings_layer.hpp
@@ -23,6 +23,7 @@ private:
 	
     bool setup() override {
         setTitle("AutoSave");
+        adjustForLoadingScreen();
 		m_title->setScale(0.575f);
 		m_title->setPositionY(171);
 

--- a/src/ui/macro_info_layer.hpp
+++ b/src/ui/macro_info_layer.hpp
@@ -20,6 +20,7 @@ private:
 
     bool setup() override {
         setTitle("Current Macro");
+        adjustForLoadingScreen();
         auto& g = Global::get();
 
         int playerInputs[2][3][2] = { { { 0, 0 }, { 0, 0 }, { 0, 0 } }, { { 0, 0 }, { 0, 0 }, { 0, 0 } } };

--- a/src/ui/pathfinder_settings_layer.hpp
+++ b/src/ui/pathfinder_settings_layer.hpp
@@ -16,6 +16,7 @@ private:
 
     bool setup() override {
         setTitle("Pathfinder");
+        adjustForLoadingScreen();
         Utils::setBackgroundColor(m_bgSprite);
 
         auto& g = Global::get();

--- a/src/ui/record_layer.cpp
+++ b/src/ui/record_layer.cpp
@@ -68,7 +68,7 @@ const std::vector<std::vector<RecordSetting>> settings {
 		{ "Frame Fix Limit:", "frame_fixes_limit", InputType::FrameFixesLimit, 0.4f },
 		{ "Lock Delta:", "lock_delta", InputType::None },
 		{ "Auto Stop Playing:", "auto_stop_playing", InputType::None },
-		{ "Pathfinder Mode:", "pathfinder_mode", InputType::Settings, 0.34f, menu_selector(PathfinderSettingsLayer::open) },
+		{ "Pathfinder Mode:", "pathfinder_mode", InputType::Settings, 0.34f, menu_selector(RecordLayer::openPathfinderSettings) },
 		{ "TPS Bypass:", "macro_tps_enabled", InputType::Tps, 0.4f },
 		{ "Speedhack:", "macro_speedhack_enabled", InputType::Speedhack, 0.4f },
 		{ "Seed:", "macro_seed_enabled", InputType::Seed, 0.4f },
@@ -377,6 +377,11 @@ void RecordLayer::openSaveMacro(CCObject*) {
 
 void RecordLayer::openLoadMacro(CCObject*) {
     LoadMacroLayer::open(static_cast<geode::Popup*>(this), nullptr);
+}
+
+void RecordLayer::openPathfinderSettings(CCObject*) {
+    if (auto* layer = PathfinderSettingsLayer::create())
+        layer->show();
 }
 
 void RecordLayer::openStarRateOverride(CCObject*) {

--- a/src/ui/record_layer.hpp
+++ b/src/ui/record_layer.hpp
@@ -110,6 +110,7 @@ public:
 	}
 
 	void openLoadMacro(CCObject*);
+	void openPathfinderSettings(CCObject*);
 	void openStarRateOverride(CCObject*);
 
 	void openSaveMacro(CCObject*);

--- a/src/ui/render_presets_layer.hpp
+++ b/src/ui/render_presets_layer.hpp
@@ -11,6 +11,7 @@ private:
 
     bool setup() override {
         setTitle("Render Presets");
+        adjustForLoadingScreen();
 
         CCScale9Sprite* bg = CCScale9Sprite::create("square02b_001.png", { 0, 0, 80, 80 });
         bg->setColor({ 0,0,0 });

--- a/src/ui/trajectory_settings_layer.hpp
+++ b/src/ui/trajectory_settings_layer.hpp
@@ -20,6 +20,7 @@ private:
 	
     bool setup() override {
         setTitle("Show Trajectory");
+        adjustForLoadingScreen();
 
     	Utils::setBackgroundColor(m_bgSprite);
 


### PR DESCRIPTION
### Motivation

- Ensure popups are positioned correctly when the loading screen offsets the game viewport. 
- Prepare a new release by updating the mod version and changelog to `1.1.0`.
- Remove development/alpha markers from feature-flag setting IDs and restore correct access to the Pathfinder settings entry.

### Description

- Bumped mod version to `1.1.0` in `mod.json` and updated `changelog.md` accordingly. 
- Updated `geobotVersion` from `"alpha 2"` to `"1.1"` in `src/gdr/gdr.hpp`.
- Removed `(Alpha)` suffixes from feature-flag keys in `mod.json` so settings now use `feature_flag_frameperfect_detection` and `feature_flag_pathfinder`.
- Added `adjustForLoadingScreen` helper to `xdb::Popup` in `src/includes.hpp` to compensate for the loading-screen viewport offset and applied this adjustment to multiple popup setup functions (`AutoclickerLayer`, `AutoSaveLayer`, `MacroInfoLayer`, `PathfinderSettingsLayer`, `RenderPresetsLayer`, `TrajectorySettingsLayer`, and others). 
- Introduced `RecordLayer::openPathfinderSettings` and updated the record settings list to call `RecordLayer::openPathfinderSettings` instead of directly referencing `PathfinderSettingsLayer::open` so the settings entry now opens the new popup correctly.

### Testing

- Built the project with `cmake && make` and the build completed successfully. 
- Ran `ctest` which reported no automated tests to execute in this tree. 
- No automated test failures were observed during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30176480ac83289b531b4c0dec39af)